### PR TITLE
ci: upgrade GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       NEXT_PUBLIC_HTTP_SERVER: http://127.0.0.1:4100
     steps:
       - name: Check out client
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v6.0.2
- upgrade actions/setup-node from v4 to v6.3.0
- keep the project runtime on Node 20; only update the GitHub Actions toolchain

## Verification
- gh release view --repo actions/checkout --json tagName,publishedAt,url
- gh release view --repo actions/setup-node --json tagName,publishedAt,url
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "client ci yaml ok"'